### PR TITLE
Make buildable with gcc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ $(eval depends += $(patsubst %.c,$(OBJDIR)/$(variant)/%.d,$(SRCS)))
 $(OBJDIR)/$(variant)/%.o: %.c
 	@echo CC $(variant) $$@
 	@mkdir -p $$(dir $$@)
-	$(hide) gcc $(CFLAGS) $(cflags) -MM -MQ $$@ -o $$(patsubst %.o,%.d,$$@) $$^
+	$(hide) $(cc) $(CFLAGS) $(cflags) -MM -MQ $$@ -o $$(patsubst %.o,%.d,$$@) $$^
 	$(hide) $(cc) $(CFLAGS) $(cflags) $$< -c -o $$@
 
 $(variant): $(objs)
@@ -56,6 +56,15 @@ cflags := -DTARGET_PI
 cc := ack -mrpi -O
 link := $(cc) -.c -t
 $(eval $(build-piface))
+
+variant := piface-gcc.elf
+cflags := -DTARGET_PI
+cc := vc4-elf-gcc -Os -save-temps
+link := $(cc) -T vc4-sram.ld
+$(eval $(build-piface))
+
+piface-gcc.bin: piface-gcc.elf
+	vc4-elf-objcopy -O binary piface-gcc.elf piface-gcc.bin
 
 variant := piface
 cflags := -DTARGET_TESTBED

--- a/src/globals.h
+++ b/src/globals.h
@@ -21,7 +21,7 @@
 
 extern char** environ;
 
-#if defined TARGET_PI
+#if defined TARGET_PI && !defined(__GNUC__)
 	#include <pi.h>
 #else
 	#define pi_phys_to_user(x) x

--- a/src/main.c
+++ b/src/main.c
@@ -9,7 +9,7 @@
 
 int main(int argc, const char* argv[])
 {
-	#if defined TARGET_PI
+	#if defined TARGET_PI && !defined(__GNUC__)
 		pi_init_uart();
 	#endif
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -5,6 +5,9 @@
  * See the file 'Copying' in the root of the distribution for the full text.
  */
 
+#ifdef __GNUC__
+#include <sys/time.h>
+#endif
 #include "globals.h"
 
 void millisleep(uint32_t s)

--- a/src/xmodem.c
+++ b/src/xmodem.c
@@ -6,6 +6,9 @@
  */
 
 #include "globals.h"
+#ifdef __GNUC__
+#include <sys/time.h>
+#endif
 #include <termios.h>
 
 static int crc16;


### PR DESCRIPTION
With this patch, piface compiles with vc4 gcc, though I've not heavily tested the result. SD card access may be broken.
